### PR TITLE
[tests] run tests only if target supports them

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![feature(
     const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd, simd_ffi,
-    target_feature,
+    target_feature, cfg_target_feature
 )]
 
 /// Platform independent SIMD vector types and operations.

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -31,7 +31,7 @@ extern "C" {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "avx", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v256::*;
     use x86::avx;
@@ -65,7 +65,4 @@ mod tests {
         let e = f64x4::new(-4.0,8.0,-4.0,12.0);
         assert_eq!(r, e);
     }
-
-
-
 }

--- a/src/x86/avx2.rs
+++ b/src/x86/avx2.rs
@@ -1044,7 +1044,7 @@ extern "C" {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "avx2", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v256::*;
     use v128::*;

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -66,7 +66,7 @@ extern {
     fn movmskps(a: f32x4) -> i32;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::sse;

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1716,7 +1716,7 @@ extern {
     fn movmskpd(a: f64x2) -> i32;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse2", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use std::os::raw::c_void;
 

--- a/src/x86/sse41.rs
+++ b/src/x86/sse41.rs
@@ -16,13 +16,13 @@ extern {
     fn pblendvb(a: __m128i, b: __m128i, mask: __m128i) -> __m128i;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse4.1", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::sse41;
 
     #[test]
-    #[target_feature = "+sse4.2"]
+    #[target_feature = "+sse4.1"]
     fn _mm_blendv_epi8() {
         let a = i8x16::new(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);

--- a/src/x86/sse42.rs
+++ b/src/x86/sse42.rs
@@ -304,7 +304,7 @@ extern {
     fn pcmpestri128(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8) -> i32;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse4.2", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::{__m128i, sse42};

--- a/src/x86/ssse3.rs
+++ b/src/x86/ssse3.rs
@@ -50,7 +50,7 @@ extern {
     fn pshufb128(a: u8x16, b: u8x16) -> u8x16;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "ssse3", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::ssse3 as ssse3;


### PR DESCRIPTION
- Compile the x86 tests for x86 or x86_64 targets only
- Compile the tests only if the features required to run them are enabled at compile-time (this means one will need to use `RUSTFLAGS="-C target-cpu=native" cargo test` to enable all tests for a particular target architecture.