### PR TITLE
Implement abm, bmi, bmi2, and tbm intrinsics

### DIFF
--- a/asm/x86_bmi2_bzhi.asm
+++ b/asm/x86_bmi2_bzhi.asm
@@ -1,0 +1,12 @@
+_bzhi_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	bzhil	%esi, %edi, %eax
+	popq	%rbp
+	retq
+_bzhi_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	bzhiq	%rsi, %rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi2_bzhi.asm
+++ b/asm/x86_bmi2_bzhi.asm
@@ -1,12 +1,12 @@
 _bzhi_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	bzhil	%esi, %edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  bzhil	%esi, %edi, %eax
+  popq	%rbp
+  retq
 _bzhi_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	bzhiq	%rsi, %rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  bzhiq	%rsi, %rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi2_bzhi.rs
+++ b/asm/x86_bmi2_bzhi.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn bzhi_u32(x: u32, mask: u32) -> u32 {
+    stdsimd::vendor::_bzhi_u32(x, mask)
+}
+
+#[no_mangle]
+pub fn bzhi_u64(x: u64, mask: u64) -> u64 {
+    stdsimd::vendor::_bzhi_u64(x, mask)
+}

--- a/asm/x86_bmi2_mulx.asm
+++ b/asm/x86_bmi2_mulx.asm
@@ -1,0 +1,17 @@
+_umulx_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	movl	%edi, %ecx
+	movl	%esi, %eax
+	imulq	%rcx, %rax
+	popq	%rbp
+	retq
+_umulx_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	mulxq	%rsi, %rcx, %rax
+	movq	%rcx, (%rdi)
+	movq	%rax, 8(%rdi)
+	movq	%rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi2_mulx.asm
+++ b/asm/x86_bmi2_mulx.asm
@@ -1,17 +1,17 @@
 _umulx_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	movl	%edi, %ecx
-	movl	%esi, %eax
-	imulq	%rcx, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  movl	%edi, %ecx
+  movl	%esi, %eax
+  imulq	%rcx, %rax
+  popq	%rbp
+  retq
 _umulx_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	mulxq	%rsi, %rcx, %rax
-	movq	%rcx, (%rdi)
-	movq	%rax, 8(%rdi)
-	movq	%rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  mulxq	%rsi, %rcx, %rax
+  movq	%rcx, (%rdi)
+  movq	%rax, 8(%rdi)
+  movq	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi2_mulx.rs
+++ b/asm/x86_bmi2_mulx.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn umulx_u32(x: u32, y: u32) -> (u32, u32) {
+    stdsimd::vendor::_mulx_u32(x, y)
+}
+
+#[no_mangle]
+pub fn umulx_u64(x: u64, y: u64) -> (u64, u64) {
+    stdsimd::vendor::_mulx_u64(x, y)
+}

--- a/asm/x86_bmi2_pdep.asm
+++ b/asm/x86_bmi2_pdep.asm
@@ -5,8 +5,8 @@ _pdep_u32:
   popq	%rbp
   retq
 _pdep_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	pdepq	%rsi, %rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  pdepq	%rsi, %rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi2_pdep.asm
+++ b/asm/x86_bmi2_pdep.asm
@@ -1,0 +1,12 @@
+_pdep_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  pdepl	%esi, %edi, %eax
+  popq	%rbp
+  retq
+_pdep_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	pdepq	%rsi, %rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi2_pdep.rs
+++ b/asm/x86_bmi2_pdep.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn pdep_u32(x: u32, mask: u32) -> u32 {
+    stdsimd::vendor::_pdep_u32(x, mask)
+}
+
+#[no_mangle]
+pub fn pdep_u64(x: u64, mask: u64) -> u64 {
+    stdsimd::vendor::_pdep_u64(x, mask)
+}

--- a/asm/x86_bmi2_pext.asm
+++ b/asm/x86_bmi2_pext.asm
@@ -5,8 +5,8 @@ _pext_u32:
   popq	%rbp
   retq
 _pext_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	pextq	%rsi, %rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  pextq	%rsi, %rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi2_pext.asm
+++ b/asm/x86_bmi2_pext.asm
@@ -1,0 +1,12 @@
+_pext_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  pextl	%esi, %edi, %eax
+  popq	%rbp
+  retq
+_pext_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	pextq	%rsi, %rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi2_pext.rs
+++ b/asm/x86_bmi2_pext.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn pext_u32(x: u32, mask: u32) -> u32 {
+    stdsimd::vendor::_pext_u32(x, mask)
+}
+
+#[no_mangle]
+pub fn pext_u64(x: u64, mask: u64) -> u64 {
+    stdsimd::vendor::_pext_u64(x, mask)
+}

--- a/asm/x86_bmi_andn.asm
+++ b/asm/x86_bmi_andn.asm
@@ -1,12 +1,12 @@
 _andn_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	andnl	%esi, %edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  andnl	%esi, %edi, %eax
+  popq	%rbp
+  retq
 _andn_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	andnq	%rsi, %rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  andnq	%rsi, %rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi_andn.asm
+++ b/asm/x86_bmi_andn.asm
@@ -1,0 +1,12 @@
+_andn_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	andnl	%esi, %edi, %eax
+	popq	%rbp
+	retq
+_andn_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	andnq	%rsi, %rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi_andn.rs
+++ b/asm/x86_bmi_andn.rs
@@ -1,0 +1,12 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn andn_u32(x: u32, y: u32) -> u32 {
+    stdsimd::vendor::_andn_u32(x, y)
+}
+
+#[no_mangle]
+pub fn andn_u64(x: u64, y: u64) -> u64 {
+    stdsimd::vendor::_andn_u64(x, y)
+}
+

--- a/asm/x86_bmi_andn.rs
+++ b/asm/x86_bmi_andn.rs
@@ -9,4 +9,3 @@ pub fn andn_u32(x: u32, y: u32) -> u32 {
 pub fn andn_u64(x: u64, y: u64) -> u64 {
     stdsimd::vendor::_andn_u64(x, y)
 }
-

--- a/asm/x86_bmi_bextr.asm
+++ b/asm/x86_bmi_bextr.asm
@@ -1,32 +1,32 @@
 _bextr_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	movzbl	%sil, %eax
-	shll	$8, %edx
-	movzwl	%dx, %ecx
-	orl	%eax, %ecx
-	bextrl	%ecx, %edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  movzbl	%sil, %eax
+  shll	$8, %edx
+  movzwl	%dx, %ecx
+  orl	%eax, %ecx
+  bextrl	%ecx, %edi, %eax
+  popq	%rbp
+  retq
 _bextr_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	movzbl	%sil, %eax
-	shlq	$8, %rdx
-	movzwl	%dx, %ecx
-	orq	%rax, %rcx
-	bextrq	%rcx, %rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  movzbl	%sil, %eax
+  shlq	$8, %rdx
+  movzwl	%dx, %ecx
+  orq	%rax, %rcx
+  bextrq	%rcx, %rdi, %rax
+  popq	%rbp
+  retq
 _bextr2_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	bextrl	%esi, %edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  bextrl	%esi, %edi, %eax
+  popq	%rbp
+  retq
 _bextr2_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	bextrq	%rsi, %rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  bextrq	%rsi, %rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi_bextr.asm
+++ b/asm/x86_bmi_bextr.asm
@@ -1,0 +1,32 @@
+_bextr_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	movzbl	%sil, %eax
+	shll	$8, %edx
+	movzwl	%dx, %ecx
+	orl	%eax, %ecx
+	bextrl	%ecx, %edi, %eax
+	popq	%rbp
+	retq
+_bextr_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	movzbl	%sil, %eax
+	shlq	$8, %rdx
+	movzwl	%dx, %ecx
+	orq	%rax, %rcx
+	bextrq	%rcx, %rdi, %rax
+	popq	%rbp
+	retq
+_bextr2_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	bextrl	%esi, %edi, %eax
+	popq	%rbp
+	retq
+_bextr2_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	bextrq	%rsi, %rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi_bextr.rs
+++ b/asm/x86_bmi_bextr.rs
@@ -1,0 +1,21 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn bextr_u32(x: u32, y: u32, z: u32) -> u32 {
+    stdsimd::vendor::_bextr_u32(x, y, z)
+}
+
+#[no_mangle]
+pub fn bextr_u64(x: u64, y: u64, z: u64) -> u64 {
+    stdsimd::vendor::_bextr_u64(x, y, z)
+}
+
+#[no_mangle]
+pub fn bextr2_u32(x: u32, y: u32) -> u32 {
+    stdsimd::vendor::_bextr2_u32(x, y)
+}
+
+#[no_mangle]
+pub fn bextr2_u64(x: u64, y: u64) -> u64 {
+    stdsimd::vendor::_bextr2_u64(x, y)
+}

--- a/asm/x86_bmi_blsi.asm
+++ b/asm/x86_bmi_blsi.asm
@@ -1,0 +1,12 @@
+_blsi_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	blsil	%edi, %eax
+	popq	%rbp
+	retq
+_blsi_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	blsiq	%rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi_blsi.asm
+++ b/asm/x86_bmi_blsi.asm
@@ -1,12 +1,12 @@
 _blsi_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	blsil	%edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsil	%edi, %eax
+  popq	%rbp
+  retq
 _blsi_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	blsiq	%rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsiq	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi_blsi.rs
+++ b/asm/x86_bmi_blsi.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blsi_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blsi_u32(x)
+}
+
+#[no_mangle]
+pub fn blsi_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blsi_u64(x)
+}

--- a/asm/x86_bmi_blsr.asm
+++ b/asm/x86_bmi_blsr.asm
@@ -1,12 +1,12 @@
 _blsr_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	blsrl	%edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsrl	%edi, %eax
+  popq	%rbp
+  retq
 _blsr_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	blsrq	%rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsrq	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi_blsr.asm
+++ b/asm/x86_bmi_blsr.asm
@@ -1,0 +1,12 @@
+_blsr_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	blsrl	%edi, %eax
+	popq	%rbp
+	retq
+_blsr_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	blsrq	%rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi_blsr.rs
+++ b/asm/x86_bmi_blsr.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blsr_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blsr_u32(x)
+}
+
+#[no_mangle]
+pub fn blsr_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blsr_u64(x)
+}

--- a/asm/x86_bmi_tzcnt.asm
+++ b/asm/x86_bmi_tzcnt.asm
@@ -1,12 +1,12 @@
 _tzcnt_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	tzcntl	%edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  tzcntl	%edi, %eax
+  popq	%rbp
+  retq
 _tzcnt_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	tzcntq	%rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  tzcntq	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_bmi_tzcnt.asm
+++ b/asm/x86_bmi_tzcnt.asm
@@ -1,0 +1,12 @@
+_tzcnt_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	tzcntl	%edi, %eax
+	popq	%rbp
+	retq
+_tzcnt_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	tzcntq	%rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_bmi_tzcnt.rs
+++ b/asm/x86_bmi_tzcnt.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn tzcnt_u32(x: u32) -> u32 {
+    stdsimd::vendor::_tzcnt_u32(x)
+}
+
+#[no_mangle]
+pub fn tzcnt_u64(x: u64) -> u64 {
+    stdsimd::vendor::_tzcnt_u64(x)
+}

--- a/asm/x86_lzcnt_lzcnt.asm
+++ b/asm/x86_lzcnt_lzcnt.asm
@@ -1,12 +1,12 @@
 _lzcnt_u32:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	lzcntl	%edi, %eax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  lzcntl	%edi, %eax
+  popq	%rbp
+  retq
 _lzcnt_u64:
-	pushq	%rbp
-	movq	%rsp, %rbp
-	lzcntq	%rdi, %rax
-	popq	%rbp
-	retq
+  pushq	%rbp
+  movq	%rsp, %rbp
+  lzcntq	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_lzcnt_lzcnt.asm
+++ b/asm/x86_lzcnt_lzcnt.asm
@@ -1,0 +1,12 @@
+_lzcnt_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	lzcntl	%edi, %eax
+	popq	%rbp
+	retq
+_lzcnt_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	lzcntq	%rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_lzcnt_lzcnt.rs
+++ b/asm/x86_lzcnt_lzcnt.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn lzcnt_u32(x: u32) -> u32 {
+    stdsimd::vendor::_lzcnt_u32(x)
+}
+
+#[no_mangle]
+pub fn lzcnt_u64(x: u64) -> u64 {
+    stdsimd::vendor::_lzcnt_u64(x)
+}

--- a/asm/x86_popcnt_popcnt.asm
+++ b/asm/x86_popcnt_popcnt.asm
@@ -1,0 +1,12 @@
+_popcnt_u32:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	popcntl	%edi, %eax
+	popq	%rbp
+	retq
+_popcnt_u64:
+	pushq	%rbp
+	movq	%rsp, %rbp
+	popcntq	%rdi, %rax
+	popq	%rbp
+	retq

--- a/asm/x86_popcnt_popcnt.rs
+++ b/asm/x86_popcnt_popcnt.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn popcnt_u32(x: u32) -> u32 {
+    stdsimd::vendor::_popcnt32(x)
+}
+
+#[no_mangle]
+pub fn popcnt_u64(x: u64) -> u64 {
+    stdsimd::vendor::_popcnt64(x)
+}

--- a/asm/x86_tbm_blcfill.asm
+++ b/asm/x86_tbm_blcfill.asm
@@ -1,0 +1,12 @@
+_blcfill_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcfill	%edi, %eax
+  popq	%rbp
+  retq
+_blcfill_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcfill	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_blcfill.rs
+++ b/asm/x86_tbm_blcfill.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blcfill_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blcfill_u32(x)
+}
+
+#[no_mangle]
+pub fn blcfill_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blcfill_u64(x)
+}

--- a/asm/x86_tbm_blci.asm
+++ b/asm/x86_tbm_blci.asm
@@ -1,0 +1,12 @@
+_blci_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blci	%edi, %eax
+  popq	%rbp
+  retq
+_blci_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blci	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_blci.rs
+++ b/asm/x86_tbm_blci.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blci_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blci_u32(x)
+}
+
+#[no_mangle]
+pub fn blci_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blci_u64(x)
+}

--- a/asm/x86_tbm_blcic.asm
+++ b/asm/x86_tbm_blcic.asm
@@ -1,0 +1,12 @@
+_blcic_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcic	%edi, %eax
+  popq	%rbp
+  retq
+_blcic_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcic	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_blcic.rs
+++ b/asm/x86_tbm_blcic.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blcic_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blcic_u32(x)
+}
+
+#[no_mangle]
+pub fn blcic_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blcic_u64(x)
+}

--- a/asm/x86_tbm_blcmsk.asm
+++ b/asm/x86_tbm_blcmsk.asm
@@ -1,0 +1,12 @@
+_blcmsk_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcmsk	%edi, %eax
+  popq	%rbp
+  retq
+_blcmsk_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcmsk	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_blcmsk.rs
+++ b/asm/x86_tbm_blcmsk.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blcmsk_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blcmsk_u32(x)
+}
+
+#[no_mangle]
+pub fn blcmsk_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blcmsk_u64(x)
+}

--- a/asm/x86_tbm_blcs.asm
+++ b/asm/x86_tbm_blcs.asm
@@ -1,0 +1,12 @@
+_blcs_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcs	%edi, %eax
+  popq	%rbp
+  retq
+_blcs_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blcs	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_blcs.rs
+++ b/asm/x86_tbm_blcs.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blcs_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blcs_u32(x)
+}
+
+#[no_mangle]
+pub fn blcs_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blcs_u64(x)
+}

--- a/asm/x86_tbm_blsfill.asm
+++ b/asm/x86_tbm_blsfill.asm
@@ -1,0 +1,12 @@
+_blsfill_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsfill	%edi, %eax
+  popq	%rbp
+  retq
+_blsfill_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsfill	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_blsfill.rs
+++ b/asm/x86_tbm_blsfill.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blsfill_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blsfill_u32(x)
+}
+
+#[no_mangle]
+pub fn blsfill_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blsfill_u64(x)
+}

--- a/asm/x86_tbm_blsic.asm
+++ b/asm/x86_tbm_blsic.asm
@@ -1,0 +1,12 @@
+_blsic_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsic	%edi, %eax
+  popq	%rbp
+  retq
+_blsic_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  blsic	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_blsic.rs
+++ b/asm/x86_tbm_blsic.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn blsic_u32(x: u32) -> u32 {
+    stdsimd::vendor::_blsic_u32(x)
+}
+
+#[no_mangle]
+pub fn blsic_u64(x: u64) -> u64 {
+    stdsimd::vendor::_blsic_u64(x)
+}

--- a/asm/x86_tbm_t1mskc.asm
+++ b/asm/x86_tbm_t1mskc.asm
@@ -1,0 +1,12 @@
+_t1mskc_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  t1mskc	%edi, %eax
+  popq	%rbp
+  retq
+_t1mskc_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  t1mskc	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_t1mskc.rs
+++ b/asm/x86_tbm_t1mskc.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn t1mskc_u32(x: u32) -> u32 {
+    stdsimd::vendor::_t1mskc_u32(x)
+}
+
+#[no_mangle]
+pub fn t1mskc_u64(x: u64) -> u64 {
+    stdsimd::vendor::_t1mskc_u64(x)
+}

--- a/asm/x86_tbm_tzmsk.asm
+++ b/asm/x86_tbm_tzmsk.asm
@@ -1,0 +1,12 @@
+_tzmsk_u32:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  tzmsk	%edi, %eax
+  popq	%rbp
+  retq
+_tzmsk_u64:
+  pushq	%rbp
+  movq	%rsp, %rbp
+  tzmsk	%rdi, %rax
+  popq	%rbp
+  retq

--- a/asm/x86_tbm_tzmsk.rs
+++ b/asm/x86_tbm_tzmsk.rs
@@ -1,0 +1,11 @@
+extern crate stdsimd;
+
+#[no_mangle]
+pub fn tzmsk_u32(x: u32) -> u32 {
+    stdsimd::vendor::_tzmsk_u32(x)
+}
+
+#[no_mangle]
+pub fn tzmsk_u64(x: u64) -> u64 {
+    stdsimd::vendor::_tzmsk_u64(x)
+}

--- a/check_asm.py
+++ b/check_asm.py
@@ -16,7 +16,6 @@ def arm_triplet(arch) :
                 'armv8' : 'aarch64-unknown-linux-gnu' }
     return triples[arch]
 
-
 class File(object):
     def __init__(self, path_rs):
         self.path_rs = path_rs
@@ -51,7 +50,6 @@ def call(args):
         print >>sys.stdout, lines
         print >>sys.stderr, "ERROR: %s" % error
 
-
 def compile_file(file):
     if verbose:
         print "Checking: " + str(file) + "..."
@@ -72,8 +70,6 @@ def compile_file(file):
     call(rustc_args_asm)
     rustc_args_ll = rustc_args + ' --emit llvm-ir {} -o {}'.format(file.path_rs, file.path_llvmir_output)
     call(rustc_args_ll)
-
-
 
     if verbose:
         print "...done!"

--- a/check_asm.py
+++ b/check_asm.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+# Script to check the assembly generated
+import os, sys
+import os.path
+from subprocess import Popen, PIPE
+import argparse
+
+asm_dir = './asm'
+
+files = set()
+verbose = False
+extern_crate = None
+
+def arm_triplet(arch) :
+    triples = { 'armv7' : 'armv7-unknown-linux-gnueabihf',
+                'armv8' : 'aarch64-unknown-linux-gnu' }
+    return triples[arch]
+
+
+class File(object):
+    def __init__(self, path_rs):
+        self.path_rs = path_rs
+        self.path_asm_should = os.path.join(os.path.splitext(path_rs)[0] + ".asm")
+        self.path_asm_output = os.path.join(os.path.splitext(path_rs)[0] + "_output.asm")
+        self.path_llvmir_output = os.path.join(os.path.splitext(path_rs)[0] + "_ir.ll")
+        self.name = os.path.splitext(os.path.basename(path_rs))[0]
+        self.feature = self.name.split("_")[1]
+        self.arch = self.name.split("_")[0]
+
+        if self.feature == "none":
+            self.feature = None
+
+    def __str__(self):
+        return  "name: " + self.name + ", path-rs: " + self.path_rs + ", path-asm: " + self.path_asm_should + ', arch: ' + self.arch + ", feature: " + str(self.feature)
+
+    def __hash__(self):
+        return hash(self.name)
+
+def find_files():
+    for dirpath, dirnames, filenames in os.walk(asm_dir):
+        for filename in [f for f in filenames if f.endswith(".rs")]:
+            files.add(File(os.path.join(dirpath, filename)))
+
+def call(args):
+    if verbose:
+        print "command: " + str(args)
+    p = Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE, shell=True)
+    lines = p.stdout.readlines()
+    if verbose and p.returncode != 0:
+        error = p.stderr.readlines()
+        print >>sys.stdout, lines
+        print >>sys.stderr, "ERROR: %s" % error
+
+
+def compile_file(file):
+    if verbose:
+        print "Checking: " + str(file) + "..."
+
+    cargo_args = 'cargo rustc --verbose --release -- -C panic=abort '
+    if file.feature:
+        cargo_args = cargo_args + '-C target-feature=+{}'.format(file.feature)
+    if file.arch == 'armv7' or file.arch == 'armv8':
+        cargo_args = cargo_args + '--target={}'.format(arm_triplet(file.arch))
+    call(str(cargo_args))
+
+    rustc_args = 'rustc --verbose -C opt-level=3 -C panic="abort" --extern %s=target/release/lib%s.rlib --crate-type lib' % (extern_crate, extern_crate);
+    if file.feature:
+        rustc_args = rustc_args + ' -C target-feature=+{}'.format(file.feature)
+    if file.arch == 'armv7' or file.arch == 'armv8':
+        rustc_args = rustc_args + ' --target={}'.format(arm_triplet(file.arch))
+    rustc_args_asm = rustc_args + ' --emit asm {} -o {}'.format(file.path_rs, file.path_asm_output)
+    call(rustc_args_asm)
+    rustc_args_ll = rustc_args + ' --emit llvm-ir {} -o {}'.format(file.path_rs, file.path_llvmir_output)
+    call(rustc_args_ll)
+
+
+
+    if verbose:
+        print "...done!"
+
+def diff_files(rustc_output, asm_snippet):
+    with open(rustc_output, 'r') as rustc_output_file:
+        rustc_output_lines = rustc_output_file.readlines()
+
+    with open(asm_snippet, 'r') as asm_snippet_file:
+        asm_snippet_lines = asm_snippet_file.readlines()
+
+    # remove all empty lines and lines starting with "."
+    rustc_output_lines = [l.strip() for l in rustc_output_lines]
+    rustc_output_lines = [l for l in rustc_output_lines if not l.startswith(".") and not len(l) == 0]
+    asm_snippet_lines = [l.strip() for l in asm_snippet_lines]
+    asm_snippet_lines = [l for l in asm_snippet_lines if not l.startswith(".") and not len(l) == 0]
+
+    results_differ = False
+
+    if len(rustc_output_lines) != len(asm_snippet_lines):
+        results_differ = True
+
+    for line_is, line_should in zip(rustc_output_lines, asm_snippet_lines):
+        if line_is != line_should:
+            results_differ = True
+
+    if results_differ:
+        print "Error: results differ"
+        print "Is:"
+        print rustc_output_lines
+        print "Should:"
+        print asm_snippet_lines
+        return False
+
+    return True
+
+def check_file(file):
+    compile_file(file)
+    return diff_files(file.path_asm_output, file.path_asm_should)
+
+def main():
+
+    parser = argparse.ArgumentParser(description='Checks ASM code')
+    parser.add_argument('-verbose', action="store_true", default=False)
+    parser.add_argument('-extern-crate', dest='extern_crate', default='stdsimd')
+    results = parser.parse_args()
+
+    global verbose
+    if results.verbose:
+        verbose = True
+
+    global extern_crate
+    extern_crate = results.extern_crate
+
+    find_files()
+
+    if verbose:
+        for f in files:
+            print f
+    error = False
+    for f in files:
+        result = check_file(f)
+        if not result:
+            error = True
+
+    if error == True:
+        exit(1)
+    else:
+        exit(0)
+
+if __name__ == "__main__":
+    main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![feature(
     const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd, simd_ffi,
-    target_feature,
+    target_feature, cfg_target_feature
 )]
 
 /// Platform independent SIMD vector types and operations.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![feature(
     const_fn, link_llvm_intrinsics, platform_intrinsics, repr_simd, simd_ffi,
-    target_feature, cfg_target_feature
+    target_feature, cfg_target_feature, i128_type
 )]
 
 /// Platform independent SIMD vector types and operations.

--- a/src/x86/abm.rs
+++ b/src/x86/abm.rs
@@ -1,0 +1,71 @@
+//! Advanced Bit Manipulation (ABM) instructions
+//! 
+//! That is, POPCNT and LZCNT. These instructions have their own CPUID bits to
+//! indicate support.
+//!
+//! TODO: it is unclear which target feature to use here. SSE4.2 should be good
+//! enough but we might need to use BMI for LZCNT if there are any problems.
+//!
+//! The references are:
+//!
+//! - [Intel 64 and IA-32 Architectures Software Developer's Manual Volume 2: Instruction Set Reference, A-Z](http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf).
+//! - [AMD64 Architecture Programmer's Manual, Volume 3: General-Purpose and System Instructions](http://support.amd.com/TechDocs/24594.pdf).
+//!
+//! [Wikipedia](https://en.wikipedia.org/wiki/Bit_Manipulation_Instruction_Sets#ABM_.28Advanced_Bit_Manipulation.29)
+//! provides a quick overview of the instructions available.
+
+
+/// Counts the leading most significant zero bits.
+///
+/// When the operand is zero, it returns its size in bits.
+#[inline(always)]
+#[target_feature = "+sse4.2"]
+pub fn _lzcnt_u32(x: u32) -> u32 { x.leading_zeros() }
+
+/// Counts the leading most significant zero bits.
+///
+/// When the operand is zero, it returns its size in bits.
+#[inline(always)]
+#[target_feature = "+sse4.2"]
+pub fn _lzcnt_u64(x: u64) -> u64 { x.leading_zeros() as u64 }
+
+/// Counts the bits that are set.
+#[inline(always)]
+#[target_feature = "+sse4.2"]
+pub fn _popcnt32(x: u32) -> u32 { x.count_ones() }
+
+/// Counts the bits that are set.
+#[inline(always)]
+#[target_feature = "+sse4.2"]
+pub fn _popcnt64(x: u64) -> u64 { x.count_ones() as u64 }
+
+#[cfg(all(test, target_feature = "sse4.2", any(target_arch = "x86", target_arch = "x86_64")))]
+mod tests {
+    use x86::abm;
+
+    #[test]
+    #[target_feature = "+sse4.2"]
+    fn _lzcnt_u32() {
+        assert_eq!(abm::_lzcnt_u32(0b0101_1010u32), 25u32);
+    }
+
+    #[test]
+    #[target_feature = "+sse4.2"]
+    fn _lzcnt_u64() {
+        assert_eq!(abm::_lzcnt_u64(0b0101_1010u64), 57u64);
+    }
+
+    #[test]
+    #[target_feature = "+sse4.2"]
+    fn _popcnt32() {
+        assert_eq!(abm::_popcnt32(0b0101_1010u32), 4);
+    }
+
+    #[test]
+    #[target_feature = "+sse4.2"]
+    fn _popcnt64() {
+        assert_eq!(abm::_popcnt64(0b0101_1010u64), 4);
+    }
+}
+
+

--- a/src/x86/abm.rs
+++ b/src/x86/abm.rs
@@ -67,5 +67,3 @@ mod tests {
         assert_eq!(abm::_popcnt64(0b0101_1010u64), 4);
     }
 }
-
-

--- a/src/x86/abm.rs
+++ b/src/x86/abm.rs
@@ -1,10 +1,6 @@
 //! Advanced Bit Manipulation (ABM) instructions
 //! 
-//! That is, POPCNT and LZCNT. These instructions have their own CPUID bits to
-//! indicate support.
-//!
-//! TODO: it is unclear which target feature to use here. SSE4.2 should be good
-//! enough but we might need to use BMI for LZCNT if there are any problems.
+//! The POPCNT and LZCNT have their own CPUID bits to indicate support.
 //!
 //! The references are:
 //!
@@ -19,50 +15,50 @@
 ///
 /// When the operand is zero, it returns its size in bits.
 #[inline(always)]
-#[target_feature = "+sse4.2"]
+#[target_feature = "+lzcnt"]
 pub fn _lzcnt_u32(x: u32) -> u32 { x.leading_zeros() }
 
 /// Counts the leading most significant zero bits.
 ///
 /// When the operand is zero, it returns its size in bits.
 #[inline(always)]
-#[target_feature = "+sse4.2"]
+#[target_feature = "+lzcnt"]
 pub fn _lzcnt_u64(x: u64) -> u64 { x.leading_zeros() as u64 }
 
 /// Counts the bits that are set.
 #[inline(always)]
-#[target_feature = "+sse4.2"]
+#[target_feature = "+popcnt"]
 pub fn _popcnt32(x: u32) -> u32 { x.count_ones() }
 
 /// Counts the bits that are set.
 #[inline(always)]
-#[target_feature = "+sse4.2"]
+#[target_feature = "+popcnt"]
 pub fn _popcnt64(x: u64) -> u64 { x.count_ones() as u64 }
 
-#[cfg(all(test, target_feature = "sse4.2", any(target_arch = "x86", target_arch = "x86_64")))]
+#[cfg(all(test, target_feature = "bmi", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use x86::abm;
 
     #[test]
-    #[target_feature = "+sse4.2"]
+    #[target_feature = "+lzcnt"]
     fn _lzcnt_u32() {
         assert_eq!(abm::_lzcnt_u32(0b0101_1010u32), 25u32);
     }
 
     #[test]
-    #[target_feature = "+sse4.2"]
+    #[target_feature = "+lzcnt"]
     fn _lzcnt_u64() {
         assert_eq!(abm::_lzcnt_u64(0b0101_1010u64), 57u64);
     }
 
     #[test]
-    #[target_feature = "+sse4.2"]
+    #[target_feature = "+popcnt"]
     fn _popcnt32() {
         assert_eq!(abm::_popcnt32(0b0101_1010u32), 4);
     }
 
     #[test]
-    #[target_feature = "+sse4.2"]
+    #[target_feature = "+popcnt"]
     fn _popcnt64() {
         assert_eq!(abm::_popcnt64(0b0101_1010u64), 4);
     }

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -31,7 +31,7 @@ extern "C" {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "avx", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v256::*;
     use x86::avx;
@@ -65,7 +65,4 @@ mod tests {
         let e = f64x4::new(-4.0,8.0,-4.0,12.0);
         assert_eq!(r, e);
     }
-
-
-
 }

--- a/src/x86/avx2.rs
+++ b/src/x86/avx2.rs
@@ -1044,7 +1044,7 @@ extern "C" {
 }
 
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "avx2", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v256::*;
     use v128::*;

--- a/src/x86/bmi.rs
+++ b/src/x86/bmi.rs
@@ -8,8 +8,10 @@
 //! provides a quick overview of the available instructions.
 
 #[allow(dead_code)]
-extern "platform-intrinsic" {
+extern "C" {
+    #[link_name="llvm.x86.bmi.bextr.32"]
     fn x86_bmi_bextr_32(x: u32, y: u32) -> u32;
+    #[link_name="llvm.x86.bmi.bextr.64"]
     fn x86_bmi_bextr_64(x: u64, y: u64) -> u64;
 }
 

--- a/src/x86/bmi.rs
+++ b/src/x86/bmi.rs
@@ -1,3 +1,12 @@
+//! Bit Manipulation Instruction (BMI) Set 1.0.
+//!
+//! The reference is [Intel 64 and IA-32 Architectures Software Developer's
+//! Manual Volume 2: Instruction Set Reference,
+//! A-Z](http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf).
+//!
+//! [Wikipedia](https://en.wikipedia.org/wiki/Bit_Manipulation_Instruction_Sets#BMI1_.28Bit_Manipulation_Instruction_Set_1.29)
+//! provides a quick overview of the available instructions.
+
 #[allow(dead_code)]
 extern "platform-intrinsic" {
     fn x86_bmi_bextr_32(x: u32, y: u32) -> u32;

--- a/src/x86/bmi.rs
+++ b/src/x86/bmi.rs
@@ -1,0 +1,257 @@
+#[allow(dead_code)]
+extern "platform-intrinsic" {
+    fn x86_bmi_bextr_32(x: u32, y: u32) -> u32;
+    fn x86_bmi_bextr_64(x: u64, y: u64) -> u64;
+}
+
+/// Extracts bits in range [`start`, `start` + `length`) from `a` into
+/// the least significant bits of the result.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
+    _bextr2_u32(a, (start & 0xffu32) | ((len & 0xffu32) << 8u32))
+}
+
+/// Extracts bits in range [`start`, `start` + `length`) from `a` into
+/// the least significant bits of the result.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _bextr_u64(a: u64, start: u64, len: u64) -> u64 {
+    _bextr2_u64(a, (start & 0xffu64) | ((len & 0xffu64) << 8u64))
+}
+
+/// Extracts bits of `a` specified by `control` into
+/// the least significant bits of the result.
+///
+/// Bits [7,0] of `control` specify the index to the first bit in the range to be
+/// extracted, and bits [15,8] specify the length of the range.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _bextr2_u32(a: u32, control: u32) -> u32 {
+    unsafe { x86_bmi_bextr_32(a, control) }
+}
+
+/// Extracts bits of `a` specified by `control` into
+/// the least significant bits of the result.
+///
+/// Bits [7,0] of `control` specify the index to the first bit in the range to be
+/// extracted, and bits [15,8] specify the length of the range.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _bextr2_u64(a: u64, control: u64) -> u64 {
+    unsafe { x86_bmi_bextr_64(a, control) }
+}
+
+/// Bitwise logical `AND` of inverted `a` with `b`.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _andn_u32(a: u32, b: u32) -> u32 {
+    !a & b
+}
+
+/// Bitwise logical `AND` of inverted `a` with `b`.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _andn_u64(a: u64, b: u64) -> u64 {
+    !a & b
+}
+
+/// Extract lowest set isolated bit.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _blsi_u32(x: u32) -> u32 {
+    x & x.wrapping_neg()
+}
+
+/// Extract lowest set isolated bit.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _blsi_u64(x: u64) -> u64 {
+    x & x.wrapping_neg()
+}
+
+/// Get mask up to lowest set bit.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _blsmsk_u32(x: u32) -> u32 {
+    x ^ (x.wrapping_sub(1u32))
+}
+
+/// Get mask up to lowest set bit.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _blsmsk_u64(x: u64) -> u64 {
+    x ^ (x.wrapping_sub(1u64))
+}
+
+/// Resets the lowest set bit of `x`.
+///
+/// If `x` is sets CF.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _blsr_u32(x: u32) -> u32 {
+    x & (x.wrapping_sub(1))
+}
+
+/// Resets the lowest set bit of `x`.
+///
+/// If `x` is sets CF.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _blsr_u64(x: u64) -> u64 {
+    x & (x.wrapping_sub(1))
+}
+
+/// Counts the number of trailing least significant zero bits.
+///
+/// When the source operand is 0, it returns its size in bits.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _tzcnt_u16(x: u16) -> u16 {
+    x.trailing_zeros() as u16
+}
+
+/// Counts the number of trailing least significant zero bits.
+///
+/// When the source operand is 0, it returns its size in bits.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _tzcnt_u32(x: u32) -> u32 {
+    x.trailing_zeros()
+}
+
+/// Counts the number of trailing least significant zero bits.
+///
+/// When the source operand is 0, it returns its size in bits.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _tzcnt_u64(x: u64) -> u64 {
+    x.trailing_zeros() as u64
+}
+
+/// Counts the number of trailing least significant zero bits.
+///
+/// When the source operand is 0, it returns its size in bits.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _mm_tzcnt_u32(x: u32) -> u32 {
+    x.trailing_zeros()
+}
+
+/// Counts the number of trailing least significant zero bits.
+///
+/// When the source operand is 0, it returns its size in bits.
+#[inline(always)]
+#[target_feature = "+bmi"]
+pub fn _mm_tzcnt_u64(x: u64) -> u64 {
+    x.trailing_zeros() as u64
+}
+
+#[cfg(all(test, target_feature = "bmi", any(target_arch = "x86", target_arch = "x86_64")))]
+mod tests {
+    use x86::bmi;
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _bextr_u32() {
+        assert_eq!(bmi::_bextr_u32(0b0101_0000u32, 4, 4), 0b0000_0101u32);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _bextr_u64() {
+        assert_eq!(bmi::_bextr_u64(0b0101_0000u64, 4, 4), 0b0000_0101u64);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _andn_u32() {
+        assert_eq!(bmi::_andn_u32(0, 0), 0);
+        assert_eq!(bmi::_andn_u32(0, 1), 1);
+        assert_eq!(bmi::_andn_u32(1, 0), 0);
+        assert_eq!(bmi::_andn_u32(1, 1), 0);
+
+        assert_eq!(bmi::_andn_u32(0b0000_0000u32, 0b0000_0000u32), 0b0000_0000u32);
+        assert_eq!(bmi::_andn_u32(0b0000_0000u32, 0b1111_1111u32), 0b1111_1111u32);
+        assert_eq!(bmi::_andn_u32(0b1111_1111u32, 0b0000_0000u32), 0b0000_0000u32);
+        assert_eq!(bmi::_andn_u32(0b1111_1111u32, 0b1111_1111u32), 0b0000_0000u32);
+        assert_eq!(bmi::_andn_u32(0b0100_0000u32, 0b0101_1101u32), 0b0001_1101u32);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _andn_u64() {
+        assert_eq!(bmi::_andn_u64(0, 0), 0);
+        assert_eq!(bmi::_andn_u64(0, 1), 1);
+        assert_eq!(bmi::_andn_u64(1, 0), 0);
+        assert_eq!(bmi::_andn_u64(1, 1), 0);
+
+        assert_eq!(bmi::_andn_u64(0b0000_0000u64, 0b0000_0000u64), 0b0000_0000u64);
+        assert_eq!(bmi::_andn_u64(0b0000_0000u64, 0b1111_1111u64), 0b1111_1111u64);
+        assert_eq!(bmi::_andn_u64(0b1111_1111u64, 0b0000_0000u64), 0b0000_0000u64);
+        assert_eq!(bmi::_andn_u64(0b1111_1111u64, 0b1111_1111u64), 0b0000_0000u64);
+        assert_eq!(bmi::_andn_u64(0b0100_0000u64, 0b0101_1101u64), 0b0001_1101u64);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _blsi_u32() {
+        assert_eq!(bmi::_blsi_u32(0b1101_0000u32), 0b0001_0000u32);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _blsi_u64() {
+        assert_eq!(bmi::_blsi_u64(0b1101_0000u64), 0b0001_0000u64);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _blsmsk_u32() {
+        assert_eq!(bmi::_blsmsk_u32(0b0011_0000u32), 0b0001_1111u32);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _blsmsk_u64() {
+        assert_eq!(bmi::_blsmsk_u64(0b0011_0000u64), 0b0001_1111u64);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _blsr_u32() {
+        /// TODO: test the behavior when the input is 0
+        assert_eq!(bmi::_blsr_u32(0b0011_0000u32), 0b0010_0000u32);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _blsr_u64() {
+        /// TODO: test the behavior when the input is 0
+        assert_eq!(bmi::_blsr_u64(0b0011_0000u64), 0b0010_0000u64);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _tzcnt_u16() {
+        assert_eq!(bmi::_tzcnt_u16(0b0000_0001u16), 0u16);
+        assert_eq!(bmi::_tzcnt_u16(0b0000_0000u16), 16u16);
+        assert_eq!(bmi::_tzcnt_u16(0b1001_0000u16), 4u16);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _tzcnt_u32() {
+        assert_eq!(bmi::_tzcnt_u32(0b0000_0001u32), 0u32);
+        assert_eq!(bmi::_tzcnt_u32(0b0000_0000u32), 32u32);
+        assert_eq!(bmi::_tzcnt_u32(0b1001_0000u32), 4u32);
+    }
+
+    #[test]
+    #[target_feature = "+bmi"]
+    fn _tzcnt_u64() {
+        assert_eq!(bmi::_tzcnt_u64(0b0000_0001u64), 0u64);
+        assert_eq!(bmi::_tzcnt_u64(0b0000_0000u64), 64u64);
+        assert_eq!(bmi::_tzcnt_u64(0b1001_0000u64), 4u64);
+    }
+}

--- a/src/x86/bmi2.rs
+++ b/src/x86/bmi2.rs
@@ -32,12 +32,18 @@ pub fn _mulx_u64(a: u64, b: u64) -> (u64, u64) {
 }
 
 #[allow(dead_code)]
-extern "platform-intrinsic" {
+extern "C" {
+    #[link_name="llvm.x86.bmi.bzhi.32"]
     fn x86_bmi2_bzhi_32(x: u32, y: u32) -> u32;
+    #[link_name="llvm.x86.bmi.bzhi.64"]
     fn x86_bmi2_bzhi_64(x: u64, y: u64) -> u64;
+    #[link_name="llvm.x86.bmi.pdep.32"]
     fn x86_bmi2_pdep_32(x: u32, y: u32) -> u32;
+    #[link_name="llvm.x86.bmi.pdep.64"]
     fn x86_bmi2_pdep_64(x: u64, y: u64) -> u64;
+    #[link_name="llvm.x86.bmi.pext.32"]
     fn x86_bmi2_pext_32(x: u32, y: u32) -> u32;
+    #[link_name="llvm.x86.bmi.pext.64"]
     fn x86_bmi2_pext_64(x: u64, y: u64) -> u64;
 }
 

--- a/src/x86/bmi2.rs
+++ b/src/x86/bmi2.rs
@@ -1,0 +1,193 @@
+/// Unsigned multiply without affecting flags.
+///
+/// Unsigned multiplication of `a` with `b` returning a pair `(lo, hi)` with
+/// the low half and the high half of the result.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _mulx_u32(a: u32, b: u32) -> (u32, u32) {
+    let result: u64 = (a as u64) * (b as u64);
+    let hi = (result >> 32) as u32;
+    (result as u32, hi)
+}
+
+/// Unsigned multiply without affecting flags.
+///
+/// Unsigned multiplication of `a` with `b` returning a pair `(lo, hi)` with
+/// the low half and the high half of the result.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _mulx_u64(a: u64, b: u64) -> (u64, u64) {
+    let result: u128 = (a as u128) * (b as u128);
+    let hi = (result >> 64) as u64;
+    (result as u64, hi)
+}
+
+#[allow(dead_code)]
+extern "platform-intrinsic" {
+    fn x86_bmi2_bzhi_32(x: u32, y: u32) -> u32;
+    fn x86_bmi2_bzhi_64(x: u64, y: u64) -> u64;
+    fn x86_bmi2_pdep_32(x: u32, y: u32) -> u32;
+    fn x86_bmi2_pdep_64(x: u64, y: u64) -> u64;
+    fn x86_bmi2_pext_32(x: u32, y: u32) -> u32;
+    fn x86_bmi2_pext_64(x: u64, y: u64) -> u64;
+}
+
+
+/// Zero higher bits of `a` >= `index`.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _bzhi_u32(a: u32, index: u32) -> u32 {
+    unsafe { x86_bmi2_bzhi_32(a, index) }
+}
+
+/// Zero higher bits of `a` >= `index`.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _bzhi_u64(a: u64, index: u64) -> u64 {
+    unsafe { x86_bmi2_bzhi_64(a, index) }
+}
+
+
+/// Scatter contiguous low order bits of `a` to the result at the positions
+/// specified by the `mask`.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _pdep_u32(a: u32, mask: u32) -> u32 {
+    unsafe { x86_bmi2_pdep_32(a, mask) }
+}
+
+/// Scatter contiguous low order bits of `a` to the result at the positions
+/// specified by the `mask`.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _pdep_u64(a: u64, mask: u64) -> u64 {
+    unsafe { x86_bmi2_pdep_64(a, mask) }
+}
+
+/// Gathers the bits of `x` specified by the `mask` into the contiguous low
+/// order bit positions of the result.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _pext_u32(a: u32, mask: u32) -> u32 {
+    unsafe { x86_bmi2_pext_32(a, mask) }
+}
+
+/// Gathers the bits of `x` specified by the `mask` into the contiguous low
+/// order bit positions of the result.
+#[inline(always)]
+#[target_feature = "+bmi2"]
+pub fn _pext_u64(a: u64, mask: u64) -> u64 {
+    unsafe { x86_bmi2_pext_64(a, mask) }
+}
+
+
+#[cfg(all(test, target_feature = "bmi2", any(target_arch = "x86", target_arch = "x86_64")))]
+mod tests {
+    use x86::bmi2;
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _pext_u32() {
+        let n  = 0b1011_1110_1001_0011u32;
+
+        let m0 = 0b0110_0011_1000_0101u32;
+        let s0 = 0b0000_0000_0011_0101u32;
+
+        let m1 = 0b1110_1011_1110_1111u32;
+        let s1 = 0b0001_0111_0100_0011u32;
+
+        assert_eq!(bmi2::_pext_u32(n, m0), s0);
+        assert_eq!(bmi2::_pext_u32(n, m1), s1);
+    }
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _pext_u64() {
+        let n  = 0b1011_1110_1001_0011u64;
+
+        let m0 = 0b0110_0011_1000_0101u64;
+        let s0 = 0b0000_0000_0011_0101u64;
+
+        let m1 = 0b1110_1011_1110_1111u64;
+        let s1 = 0b0001_0111_0100_0011u64;
+
+        assert_eq!(bmi2::_pext_u64(n, m0), s0);
+        assert_eq!(bmi2::_pext_u64(n, m1), s1);
+    }
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _pdep_u32() {
+        let n  = 0b1011_1110_1001_0011u32;
+
+        let m0 = 0b0110_0011_1000_0101u32;
+        let s0 = 0b0000_0010_0000_0101u32;
+
+        let m1 = 0b1110_1011_1110_1111u32;
+        let s1 = 0b1110_1001_0010_0011u32;
+
+        assert_eq!(bmi2::_pdep_u32(n, m0), s0);
+        assert_eq!(bmi2::_pdep_u32(n, m1), s1);
+    }
+
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _pdep_u64() {
+        let n  = 0b1011_1110_1001_0011u64;
+
+        let m0 = 0b0110_0011_1000_0101u64;
+        let s0 = 0b0000_0010_0000_0101u64;
+
+        let m1 = 0b1110_1011_1110_1111u64;
+        let s1 = 0b1110_1001_0010_0011u64;
+
+        assert_eq!(bmi2::_pdep_u64(n, m0), s0);
+        assert_eq!(bmi2::_pdep_u64(n, m1), s1);
+    }
+
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _bzhi_u32() {
+        let n = 0b1111_0010u32;
+        let s = 0b0001_0010u32;
+        assert_eq!(bmi2::_bzhi_u32(n, 5), s);
+    }
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _bzhi_u64() {
+        let n = 0b1111_0010u64;
+        let s = 0b0001_0010u64;
+        assert_eq!(bmi2::_bzhi_u64(n, 5), s);
+    }
+
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _mulx_u32() {
+        let a: u32 = 4_294_967_200;
+        let b: u32 = 2;
+        let (lo, hi): (u32, u32)  = bmi2::_mulx_u32(a, b);
+        // result = 8589934400
+        //        = 0b0001_1111_1111_1111_1111_1111_1111_0100_0000u64
+        //            ^~hi ^~lo~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        assert_eq!(lo, 0b1111_1111_1111_1111_1111_1111_0100_0000u32);
+        assert_eq!(hi, 0b0001u32);
+    }
+
+    #[test]
+    #[target_feature = "+bmi2"]
+    fn _mulx_u64() {
+        let a: u64 = 9_223_372_036_854_775_800;
+        let b: u64 = 100;
+        let (lo, hi): (u64, u64)  = bmi2::_mulx_u64(a, b);
+        // result = 922337203685477580000
+        //        = 0b00110001_11111111_11111111_11111111_11111111_11111111_11111111_11111100_11100000u128
+        //            ^~hi~~~~ ^~lo~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        assert_eq!(lo, 0b11111111_11111111_11111111_11111111_11111111_11111111_11111100_11100000u64);
+        assert_eq!(hi, 0b00110001u64);
+    }
+
+}

--- a/src/x86/bmi2.rs
+++ b/src/x86/bmi2.rs
@@ -1,3 +1,12 @@
+//! Bit Manipulation Instruction (BMI) Set 2.0.
+//!
+//! The reference is [Intel 64 and IA-32 Architectures Software Developer's
+//! Manual Volume 2: Instruction Set Reference,
+//! A-Z](http://www.intel.de/content/dam/www/public/us/en/documents/manuals/64-ia-32-architectures-software-developer-instruction-set-reference-manual-325383.pdf).
+//!
+//! [Wikipedia](https://en.wikipedia.org/wiki/Bit_Manipulation_Instruction_Sets#BMI2_.28Bit_Manipulation_Instruction_Set_2.29)
+//! provides a quick overview of the available instructions.
+
 /// Unsigned multiply without affecting flags.
 ///
 /// Unsigned multiplication of `a` with `b` returning a pair `(lo, hi)` with

--- a/src/x86/bmi2.rs
+++ b/src/x86/bmi2.rs
@@ -95,7 +95,6 @@ pub fn _pext_u64(a: u64, mask: u64) -> u64 {
     unsafe { x86_bmi2_pext_64(a, mask) }
 }
 
-
 #[cfg(all(test, target_feature = "bmi2", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use x86::bmi2;
@@ -145,7 +144,6 @@ mod tests {
         assert_eq!(bmi2::_pdep_u32(n, m1), s1);
     }
 
-
     #[test]
     #[target_feature = "+bmi2"]
     fn _pdep_u64() {
@@ -160,7 +158,6 @@ mod tests {
         assert_eq!(bmi2::_pdep_u64(n, m0), s0);
         assert_eq!(bmi2::_pdep_u64(n, m1), s1);
     }
-
 
     #[test]
     #[target_feature = "+bmi2"]
@@ -177,7 +174,6 @@ mod tests {
         let s = 0b0001_0010u64;
         assert_eq!(bmi2::_bzhi_u64(n, 5), s);
     }
-
 
     #[test]
     #[target_feature = "+bmi2"]
@@ -204,5 +200,4 @@ mod tests {
         assert_eq!(lo, 0b11111111_11111111_11111111_11111111_11111111_11111111_11111100_11100000u64);
         assert_eq!(hi, 0b00110001u64);
     }
-
 }

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -5,6 +5,7 @@ pub use self::sse41::*;
 pub use self::sse42::*;
 pub use self::avx::*;
 pub use self::avx2::*;
+pub use self::bmi::*;
 
 #[allow(non_camel_case_types)]
 pub type __m128i = ::v128::i8x16;
@@ -18,3 +19,5 @@ mod sse41;
 mod sse42;
 mod avx;
 mod avx2;
+
+mod bmi;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -5,7 +5,11 @@ pub use self::sse41::*;
 pub use self::sse42::*;
 pub use self::avx::*;
 pub use self::avx2::*;
+
+pub use self::abm::*;
 pub use self::bmi::*;
+pub use self::bmi2::*;
+pub use self::tbm::*;
 
 #[allow(non_camel_case_types)]
 pub type __m128i = ::v128::i8x16;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -20,5 +20,6 @@ mod sse42;
 mod avx;
 mod avx2;
 
+mod abm;
 mod bmi;
 mod bmi2;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -21,3 +21,4 @@ mod avx;
 mod avx2;
 
 mod bmi;
+mod bmi2;

--- a/src/x86/mod.rs
+++ b/src/x86/mod.rs
@@ -23,3 +23,4 @@ mod avx2;
 mod abm;
 mod bmi;
 mod bmi2;
+mod tbm;

--- a/src/x86/sse.rs
+++ b/src/x86/sse.rs
@@ -66,7 +66,7 @@ extern {
     fn movmskps(a: f32x4) -> i32;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::sse;

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -1716,7 +1716,7 @@ extern {
     fn movmskpd(a: f64x2) -> i32;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse2", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use std::os::raw::c_void;
 

--- a/src/x86/sse41.rs
+++ b/src/x86/sse41.rs
@@ -16,13 +16,13 @@ extern {
     fn pblendvb(a: __m128i, b: __m128i, mask: __m128i) -> __m128i;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse4.1", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::sse41;
 
     #[test]
-    #[target_feature = "+sse4.2"]
+    #[target_feature = "+sse4.1"]
     fn _mm_blendv_epi8() {
         let a = i8x16::new(
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);

--- a/src/x86/sse42.rs
+++ b/src/x86/sse42.rs
@@ -304,7 +304,7 @@ extern {
     fn pcmpestri128(a: __m128i, la: i32, b: __m128i, lb: i32, imm8: i8) -> i32;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "sse4.2", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::{__m128i, sse42};

--- a/src/x86/ssse3.rs
+++ b/src/x86/ssse3.rs
@@ -50,7 +50,7 @@ extern {
     fn pshufb128(a: u8x16, b: u8x16) -> u8x16;
 }
 
-#[cfg(test)]
+#[cfg(all(test, target_feature = "ssse3", any(target_arch = "x86", target_arch = "x86_64")))]
 mod tests {
     use v128::*;
     use x86::ssse3 as ssse3;

--- a/src/x86/tbm.rs
+++ b/src/x86/tbm.rs
@@ -7,10 +7,13 @@
 //! [Wikipedia](https://en.wikipedia.org/wiki/Bit_Manipulation_Instruction_Sets#TBM_.28Trailing_Bit_Manipulation.29)
 //! provides a quick overview of the available instructions.
 
-/* // TODO: LLVM-CODEGEN ERROR
+// TODO: LLVM-CODEGEN ERROR: LLVM ERROR: Cannot select: intrinsic %llvm.x86.tbm.bextri.u32
+/*
 #[allow(dead_code)]
-extern "platform-intrinsic" {
+extern "C" {
+    #[link_name="llvm.x86.tbm.bextri.u32"]
     fn x86_tbm_bextri_u32(a: u32, y: u32) -> u32;
+    #[link_name="llvm.x86.tbm.bextri.u64"]
     fn x86_tbm_bextri_u64(x: u64, y: u64) -> u64;
 }
 

--- a/src/x86/tbm.rs
+++ b/src/x86/tbm.rs
@@ -1,0 +1,369 @@
+//! Trailing Bit Manipulation (TBM) instruction set.
+//!
+//! The reference is [AMD64 Architecture Programmer's Manual, Volume 3:
+//! General-Purpose and System
+//! Instructions](http://support.amd.com/TechDocs/24594.pdf).
+//!
+//! [Wikipedia](https://en.wikipedia.org/wiki/Bit_Manipulation_Instruction_Sets#TBM_.28Trailing_Bit_Manipulation.29)
+//! provides a quick overview of the available instructions.
+
+/* // TODO: LLVM-CODEGEN ERROR
+#[allow(dead_code)]
+extern "platform-intrinsic" {
+    fn x86_tbm_bextri_u32(a: u32, y: u32) -> u32;
+    fn x86_tbm_bextri_u64(x: u64, y: u64) -> u64;
+}
+
+/// Extracts bits in range [`start`, `start` + `length`) from `a` into
+/// the least significant bits of the result.
+#[inline(always)]
+#[target_feature = "+tbm"] 
+pub fn _bextr_u32(a: u32, start: u32, len: u32) -> u32 {
+    _bextr2_u32(a, (start & 0xffu32) | ((len & 0xffu32) << 8u32))
+}
+
+/// Extracts bits in range [`start`, `start` + `length`) from `a` into
+/// the least significant bits of the result.
+#[inline(always)]
+#[target_feature = "+tbm"] 
+pub fn _bextr_u64(a: u64, start: u64, len: u64) -> u64 {
+    _bextr2_u64(a, (start & 0xffu64) | ((len & 0xffu64) << 8u64))
+}
+
+/// Extracts bits of `a` specified by `control` into
+/// the least significant bits of the result.
+///
+/// Bits [7,0] of `control` specify the index to the first bit in the range to be
+/// extracted, and bits [15,8] specify the length of the range.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _bextr2_u32(a: u32, control: u32) -> u32 {
+    unsafe { x86_tbm_bextri_u32(a, control) }
+}
+
+/// Extracts bits of `a` specified by `control` into
+/// the least significant bits of the result.
+///
+/// Bits [7,0] of `control` specify the index to the first bit in the range to be
+/// extracted, and bits [15,8] specify the length of the range.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _bextr2_u64(a: u64, control: u64) -> u64 {
+    unsafe { x86_tbm_bextri_u64(a, control) }
+}
+*/
+
+/// Clears all bits below the least significant zero bit of `x`.
+///
+/// If there is no zero bit in `x`, it returns zero.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcfill_u32(x: u32) -> u32 {
+    x & (x.wrapping_add(1))
+}
+
+/// Clears all bits below the least significant zero bit of `x`.
+///
+/// If there is no zero bit in `x`, it returns zero.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcfill_u64(x: u64) -> u64 {
+    x & (x.wrapping_add(1))
+}
+
+/// Sets all bits of `x` to 1 except for the least significant zero bit.
+///
+/// If there is no zero bit in `x`, it sets all bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blci_u32(x: u32) -> u32 {
+    x | !(x.wrapping_add(1))
+}
+
+/// Sets all bits of `x` to 1 except for the least significant zero bit.
+///
+/// If there is no zero bit in `x`, it sets all bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blci_u64(x: u64) -> u64 {
+    x | !(x.wrapping_add(1))
+}
+
+/// Sets the least significant zero bit of `x` and clears all other bits.
+///
+/// If there is no zero bit in `x`, it returns zero.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcic_u32(x: u32) -> u32 {
+    !x & (x.wrapping_add(1))
+}
+
+/// Sets the least significant zero bit of `x` and clears all other bits.
+///
+/// If there is no zero bit in `x`, it returns zero.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcic_u64(x: u64) -> u64 {
+    !x & (x.wrapping_add(1))
+}
+
+/// Sets the least significant zero bit of `x` and clears all bits above that bit.
+///
+/// If there is no zero bit in `x`, it sets all the bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcmsk_u32(x: u32) -> u32 {
+    x ^ (x.wrapping_add(1))
+}
+
+/// Sets the least significant zero bit of `x` and clears all bits above that bit.
+///
+/// If there is no zero bit in `x`, it sets all the bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcmsk_u64(x: u64) -> u64 {
+    x ^ (x.wrapping_add(1))
+}
+
+/// Sets the least significant zero bit of `x`.
+///
+/// If there is no zero bit in `x`, it returns `x`.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcs_u32(x: u32) -> u32 {
+    x | (x.wrapping_add(1))
+}
+
+/// Sets the least significant zero bit of `x`.
+///
+/// If there is no zero bit in `x`, it returns `x`.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blcs_u64(x: u64) -> u64 {
+    x | x.wrapping_add(1)
+}
+
+/// Sets all bits of `x` below the least significant one.
+///
+/// If there is no set bit in `x`, it sets all the bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blsfill_u32(x: u32) -> u32 {
+    x | (x.wrapping_sub(1))
+}
+
+/// Sets all bits of `x` below the least significant one.
+///
+/// If there is no set bit in `x`, it sets all the bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blsfill_u64(x: u64) -> u64 {
+    x | (x.wrapping_sub(1))
+}
+
+/// Clears least significant bit and sets all other bits.
+///
+/// If there is no set bit in `x`, it sets all the bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blsic_u32(x: u32) -> u32 {
+    !x | (x.wrapping_sub(1))
+}
+
+/// Clears least significant bit and sets all other bits.
+///
+/// If there is no set bit in `x`, it sets all the bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _blsic_u64(x: u64) -> u64 {
+    !x | (x.wrapping_sub(1))
+}
+
+/// Clears all bits below the least significant zero of `x` and sets all other
+/// bits.
+///
+/// If the least significant bit of `x` is 0, it sets all bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _t1mskc_u32(x: u32) -> u32 {
+    !x | (x.wrapping_add(1))
+}
+
+/// Clears all bits below the least significant zero of `x` and sets all other
+/// bits.
+///
+/// If the least significant bit of `x` is 0, it sets all bits.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _t1mskc_u64(x: u64) -> u64 {
+    !x | (x.wrapping_add(1))
+}
+
+/// Sets all bits below the least significant one of `x` and clears all other
+/// bits.
+///
+/// If the least significant bit of `x` is 1, it returns zero.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _tzmsk_u32(x: u32) -> u32 {
+    !x & (x.wrapping_sub(1))
+}
+
+/// Sets all bits below the least significant one of `x` and clears all other
+/// bits.
+///
+/// If the least significant bit of `x` is 1, it returns zero.
+#[inline(always)]
+#[target_feature = "+tbm"]
+pub fn _tzmsk_u64(x: u64) -> u64 {
+    !x & (x.wrapping_sub(1))
+}
+
+#[cfg(all(test, target_feature = "tbm", any(target_arch = "x86", target_arch = "x86_64")))]
+mod tests {
+    use x86::tbm;
+
+    /*
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _bextr_u32() {
+        assert_eq!(tbm::_bextr_u32(0b0101_0000u32, 4, 4), 0b0000_0101u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _bextr_u64() {
+        assert_eq!(tbm::_bextr_u64(0b0101_0000u64, 4, 4), 0b0000_0101u64);
+    }
+    */
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcfill_u32() {
+        assert_eq!(tbm::_blcfill_u32(0b0101_0111u32), 0b0101_0000u32);
+        assert_eq!(tbm::_blcfill_u32(0b1111_1111u32), 0u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcfill_u64() {
+        assert_eq!(tbm::_blcfill_u64(0b0101_0111u64), 0b0101_0000u64);
+        assert_eq!(tbm::_blcfill_u64(0b1111_1111u64), 0u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blci_u32() {
+        assert_eq!(tbm::_blci_u32(0b0101_0000u32),
+                   0b1111_1111_1111_1111_1111_1111_1111_1110u32);
+        assert_eq!(tbm::_blci_u32(0b1111_1111u32),
+                   0b1111_1111_1111_1111_1111_1110_1111_1111u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blci_u64() {
+        assert_eq!(tbm::_blci_u64(0b0101_0000u64),
+                   0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1110u64);
+        assert_eq!(tbm::_blci_u64(0b1111_1111u64),
+                   0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1110_1111_1111u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcic_u32() {
+        assert_eq!(tbm::_blcic_u32(0b0101_0001u32), 0b0000_0010u32);
+        assert_eq!(tbm::_blcic_u32(0b1111_1111u32), 0b1_0000_0000u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcic_u64() {
+        assert_eq!(tbm::_blcic_u64(0b0101_0001u64), 0b0000_0010u64);
+        assert_eq!(tbm::_blcic_u64(0b1111_1111u64), 0b1_0000_0000u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcmsk_u32() {
+        assert_eq!(tbm::_blcmsk_u32(0b0101_0001u32), 0b0000_0011u32);
+        assert_eq!(tbm::_blcmsk_u32(0b1111_1111u32), 0b1_1111_1111u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcmsk_u64() {
+        assert_eq!(tbm::_blcmsk_u64(0b0101_0001u64), 0b0000_0011u64);
+        assert_eq!(tbm::_blcmsk_u64(0b1111_1111u64), 0b1_1111_1111u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcs_u32() {
+       assert_eq!(tbm::_blcs_u32(0b0101_0001u32), 0b0101_0011u32);
+       assert_eq!(tbm::_blcs_u32(0b1111_1111u32), 0b1_1111_1111u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blcs_u64() {
+       assert_eq!(tbm::_blcs_u64(0b0101_0001u64), 0b0101_0011u64);
+       assert_eq!(tbm::_blcs_u64(0b1111_1111u64), 0b1_1111_1111u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blsfill_u32() {
+        assert_eq!(tbm::_blsfill_u32(0b0101_0100u32), 0b0101_0111u32);
+        assert_eq!(tbm::_blsfill_u32(0u32), 0b1111_1111_1111_1111_1111_1111_1111_1111u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blsfill_u64() {
+        assert_eq!(tbm::_blsfill_u64(0b0101_0100u64), 0b0101_0111u64);
+        assert_eq!(tbm::_blsfill_u64(0u64), 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blsic_u32() {
+        assert_eq!(tbm::_blsic_u32(0b0101_0100u32), 0b1111_1111_1111_1111_1111_1111_1111_1011u32);
+        assert_eq!(tbm::_blsic_u32(0u32), 0b1111_1111_1111_1111_1111_1111_1111_1111u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _blsic_u64() {
+        assert_eq!(tbm::_blsic_u64(0b0101_0100u64), 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1011u64);
+       assert_eq!(tbm::_blsic_u64(0u64), 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _t1mskc_u32() {
+       assert_eq!(tbm::_t1mskc_u32(0b0101_0111u32), 0b1111_1111_1111_1111_1111_1111_1111_1000u32);
+       assert_eq!(tbm::_t1mskc_u32(0u32), 0b1111_1111_1111_1111_1111_1111_1111_1111u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _t1mksc_u64() {
+       assert_eq!(tbm::_t1mskc_u64(0b0101_0111u64), 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1000u64);
+       assert_eq!(tbm::_t1mskc_u64(0u64), 0b1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111u64);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _tzmsk_u32() {
+        assert_eq!(tbm::_tzmsk_u32(0b0101_1000u32), 0b0000_0111u32);
+        assert_eq!(tbm::_tzmsk_u32(0b0101_1001u32), 0b0000_0000u32);
+    }
+
+    #[test]
+    #[target_feature = "+tbm"]
+    fn _tzmsk_u64() {
+        assert_eq!(tbm::_tzmsk_u64(0b0101_1000u64), 0b0000_0111u64);
+        assert_eq!(tbm::_tzmsk_u64(0b0101_1001u64), 0b0000_0000u64);
+    }
+}


### PR DESCRIPTION
Implements all ABM, BMI, BMI2, and TBM intrinsics: 

- abm: POPCNT, LZCNT
- bmi: ANDN, BEXTR, BLSI ,BLSMSK, BLSR, TZCNT
- bmi2: BZHI , MULX, PDEP, PEXT
- tbm: BLCFILL, BLCI, BLCIC, BLCMSK, BLCS, BLSFILL, BLSIC, T1MSKC, TZMKS

This PR compiles the tests only for those architectures that support them. That is, to compile and run all the tests that a CPU can target one should use `RUSTFLAGS="-C target-cpu=native" cargo test`. 

Known issues:
- Add TBM's BEXTRI (the only instruction missing) which triggers an LLVM code-gen error #12 .